### PR TITLE
fix: use session variable rather than boto3 when you use AWS profile

### DIFF
--- a/find-incomplete-s3-multipart-uploads.py
+++ b/find-incomplete-s3-multipart-uploads.py
@@ -50,7 +50,7 @@ else:
     session = boto3.session.Session()
 
 # Create an S3 client
-s3 = boto3.client('s3')
+s3 = session.client('s3')
 
 # Call S3 to list current buckets
 response = s3.list_buckets()


### PR DESCRIPTION
# Description

There is a bug when you use AWS profile because the variable "session" is created correctly but is never used, and when will create an S3 object, it is using a boto3 instead.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](/master/CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
